### PR TITLE
When possible, don't use a namespace prefix

### DIFF
--- a/xspf.py
+++ b/xspf.py
@@ -12,6 +12,10 @@ class XspfBase(object):
                 el = ET.SubElement(parent, "{{{0}}}{1}".format(self.NS, attr))
                 el.text = value
 
+# Avoid namespace prefixes, VLC doesn't like it
+if hasattr(ET, 'register_namespace'):
+    ET.register_namespace('', XspfBase.NS)
+
 # in-place prettyprint formatter
 # From http://effbot.org/zone/element-lib.htm
 def indent(elem, level=0):


### PR DESCRIPTION
Some media players (like VLC) can't parse the playlist correctly if the XSPF tags are prefixed with the autogenerated namespace `ns0:`, even if it's semantically correct.

The [function in question](http://docs.python.org/2/library/xml.etree.elementtree#xml.etree.ElementTree.register_namespace) was introduced in Python 2.7.
